### PR TITLE
remove infinate loop in watcher.watch_multicast

### DIFF
--- a/hubpackage/src/UPnP/watcher.lua
+++ b/hubpackage/src/UPnP/watcher.lua
@@ -233,10 +233,10 @@ end
   
 -- Channel Hander:  Receive and process discovery response messages
 local function watch_multicast(_, sock)
-
+  local data, rip
   repeat
 
-    local data, rip, _ = sock:receivefrom()
+    data, rip, _ = sock:receivefrom()
     
     if data and (rip ~= 'timeout') then
     


### PR DESCRIPTION
Hi, I have been looking over you driver here to try and figure out how cosock is getting into an invalid state, [that you reported here](https://community.smartthings.com/t/st-edge-driver-lifecycle-inquiries/230733/32). While reviewing I noticed that you have an infinite loop here in `watch_multicast` and since this is registered as the channel handler when the socket is ready to this I think is leading to some extra slow downs in your driver. 